### PR TITLE
Implement pressed state for MacosSwitch, MacosRadioButton, and MacosCheckbox

### DIFF
--- a/README.md
+++ b/README.md
@@ -682,6 +682,8 @@ MacosSwitch(
 ),
 ```
 
+The `MacosSwitch` widget also has a pressed down state with a slight dimming effect and dark overlay while the mouse is pressed down.
+
 Learn more about switches [here](https://developer.apple.com/design/human-interface-guidelines/toggles).
 
 ## MacosSegmentedControl

--- a/test/buttons/checkbox_test.dart
+++ b/test/buttons/checkbox_test.dart
@@ -70,4 +70,49 @@ void main() {
       ],
     );
   });
+
+  testWidgets('MacosCheckbox pressed down state', (tester) async {
+    bool? checked;
+    await tester.pumpWidget(
+      MacosApp(
+        home: MacosWindow(
+          child: MacosScaffold(
+            children: [
+              ContentArea(
+                builder: (context, _) {
+                  return StatefulBuilder(
+                    builder: (context, setState) {
+                      return MacosCheckbox(
+                        value: checked,
+                        onChanged: (value) {
+                          setState(() => checked = value);
+                        },
+                      );
+                    },
+                  );
+                },
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+
+    final macosCheckbox = find.byType(MacosCheckbox);
+    expect(macosCheckbox, findsOneWidget);
+
+    final gesture = await tester.startGesture(tester.getCenter(macosCheckbox));
+    await tester.pump();
+    expect(
+      tester.widget<MacosCheckbox>(macosCheckbox).buttonHeldDown,
+      true,
+    );
+
+    await gesture.up();
+    await tester.pump();
+    expect(
+      tester.widget<MacosCheckbox>(macosCheckbox).buttonHeldDown,
+      false,
+    );
+  });
 }

--- a/test/buttons/radio_button_test.dart
+++ b/test/buttons/radio_button_test.dart
@@ -105,4 +105,48 @@ void main() {
       ],
     );
   });
+
+  testWidgets('MacosRadioButton pressed down state', (tester) async {
+    TestOptions? selectedOption = TestOptions.first;
+    await tester.pumpWidget(
+      MacosApp(
+        home: MacosWindow(
+          child: MacosScaffold(
+            children: [
+              ContentArea(
+                builder: (context, _) {
+                  return Center(
+                    child: MacosRadioButton<TestOptions>(
+                      value: TestOptions.first,
+                      groupValue: selectedOption,
+                      onChanged: (value) {
+                        selectedOption = value;
+                      },
+                    ),
+                  );
+                },
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+
+    final macosRadioButton = find.byType(MacosRadioButton<TestOptions>);
+    expect(macosRadioButton, findsOneWidget);
+
+    final gesture = await tester.startGesture(tester.getCenter(macosRadioButton));
+    await tester.pump();
+    expect(
+      tester.widget<MacosRadioButton<TestOptions>>(macosRadioButton).buttonHeldDown,
+      true,
+    );
+
+    await gesture.up();
+    await tester.pump();
+    expect(
+      tester.widget<MacosRadioButton<TestOptions>>(macosRadioButton).buttonHeldDown,
+      false,
+    );
+  });
 }

--- a/test/buttons/switch_test.dart
+++ b/test/buttons/switch_test.dart
@@ -62,4 +62,47 @@ void main() {
       ],
     );
   });
+
+  testWidgets('MacosSwitch pressed down state', (tester) async {
+    bool selected = false;
+    await tester.pumpWidget(
+      MacosApp(
+        home: MacosWindow(
+          child: MacosScaffold(
+            children: [
+              ContentArea(
+                builder: (context, _) {
+                  return Center(
+                    child: MacosSwitch(
+                      value: selected,
+                      onChanged: (value) {
+                        selected = value;
+                      },
+                    ),
+                  );
+                },
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+
+    final macosSwitch = find.byType(MacosSwitch);
+    expect(macosSwitch, findsOneWidget);
+
+    final gesture = await tester.startGesture(tester.getCenter(macosSwitch));
+    await tester.pump();
+    expect(
+      tester.widget<MacosSwitch>(macosSwitch).buttonHeldDown,
+      true,
+    );
+
+    await gesture.up();
+    await tester.pump();
+    expect(
+      tester.widget<MacosSwitch>(macosSwitch).buttonHeldDown,
+      false,
+    );
+  });
 }


### PR DESCRIPTION
Add pressed down state for MacosSwitch, MacosRadioButton, and MacosCheckbox widgets.

* Add tests for the pressed down state of MacosSwitch in `test/buttons/switch_test.dart`.
* Add tests for the pressed down state of MacosRadioButton in `test/buttons/radio_button_test.dart`.
* Add tests for the pressed down state of MacosCheckbox in `test/buttons/checkbox_test.dart`.

